### PR TITLE
Fix undefined index notices …

### DIFF
--- a/cmb2-conditionals.php
+++ b/cmb2-conditionals.php
@@ -70,6 +70,11 @@ function cmb2_conditional_filter_data_to_save(CMB2 $cmb2, $object_id)
 
 			$conditional_value = ($decoded_conditional_value = @json_decode($conditional_value)) ? $decoded_conditional_value : $conditional_value;
 
+			if(!isset($cmb2->data_to_save[$conditional_id])) {
+				unset($cmb2->data_to_save[$field_id]);
+				continue;
+			}
+
 			if(is_array($conditional_value) && !in_array($cmb2->data_to_save[$conditional_id], $conditional_value)) {
 				unset($cmb2->data_to_save[$field_id]);
 				continue;
@@ -81,7 +86,7 @@ function cmb2_conditional_filter_data_to_save(CMB2 $cmb2, $object_id)
 			}
 		}
 
-		if(!$cmb2->data_to_save[$conditional_id]) {
+		if(!isset($cmb2->data_to_save[$conditional_id]) || !$cmb2->data_to_save[$conditional_id]) {
 			unset($cmb2->data_to_save[$field_id]);
 			continue;
 		}


### PR DESCRIPTION
… when the field on which a conditional field depends is not available.

Easy enough to reproduce - include the example file & save a new post without filling in any data.

You'll see the following notices (line nr may differ):
```
Undefined index: _yourprefix2_demo_address in /path/to/wp-content/plugins/cmb2-conditionals/cmb2-conditionals.php on line 84
Undefined index: _yourprefix2_demo_checkbox in /path/to/wp-content/plugins/cmb2-conditionals/cmb2-conditionals.php on line 84
Undefined index: _yourprefix2_demo_checkbox in /path/to/wp-content/plugins/cmb2-conditionals/cmb2-conditionals.php on line 78
```

This PR fixed those notices and adds the logic to deal with this situation properly.