### PR TITLE
Minor automated testing tweaks.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,8 +24,10 @@ matrix:
         # aliased to a recent 5.6.x version
         - php: '5.6'
           env: SNIFF=1
-        # aliased to a recent 7.x version
+        # aliased to a recent 7.0.x version
         - php: '7.0'
+        # aliased to a recent 7.1.x version
+        - php: '7.1'
         # aliased to a recent hhvm version
         - php: 'hhvm'
 

--- a/example-functions.php
+++ b/example-functions.php
@@ -143,7 +143,7 @@ function yourprefix_register_conditionals_demo_metabox() {
 		'attributes' => array(
 			'required'               => true, // Will be required only if visible.
 			'data-conditional-id'    => $prefix . 'reason_2',
-			'data-conditional-value' => json_encode( array( 'other_price', 'other_quality' ) ),
+			'data-conditional-value' => wp_json_encode( array( 'other_price', 'other_quality' ) ),
 		),
 	) );
 
@@ -217,7 +217,7 @@ function yourprefix_register_conditionals_demo_metabox() {
 		'type'       => 'text',
 		'attributes' => array(
 			'data-conditional-id'    => $prefix . 'multi-checkbox',
-			'data-conditional-value' => json_encode( array( 'check1', 'check3' ) ),
+			'data-conditional-value' => wp_json_encode( array( 'check1', 'check3' ) ),
 		),
 	) );
 
@@ -246,7 +246,7 @@ function yourprefix_register_conditionals_demo_metabox() {
 		'type'       => 'text_small',
 		'attributes' => array(
 			'required'               => true, // Will be required only if visible.
-			'data-conditional-id'    => json_encode( array( $group_id, 'checkbox' ) ),
+			'data-conditional-id'    => wp_json_encode( array( $group_id, 'checkbox' ) ),
 			'data-conditional-value' => 'on',
 		),
 	) );

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -8,6 +8,7 @@
 	<rule ref="WordPress" />
 
 	<!-- ##### Sniffs for PHP cross-version compatibility ##### -->
-	<rule ref="PHPCompatibility" />
+	<config name="testVersion" value="5.2-99.0"/>
+	<rule ref="PHPCompatibility"/>
 
 </ruleset>


### PR DESCRIPTION
* 	Set `testVersion` for PHPCompatibility so we receive the messages for the right PHP versions.
* 	Add PHP 7.1 to the travis test matrix as it will be released soon.
* 	Minor code style fix in anticipation of the WPCS 0.10.0 release.