### PR TITLE
Will not work when including cmb2 in a theme

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 vendor
 composer.lock
+.idea

--- a/cmb2-conditionals.php
+++ b/cmb2-conditionals.php
@@ -253,7 +253,7 @@ if ( ! class_exists( 'CMB2_Conditionals' ) ) {
 	 * check can be removed once the min version for this plugin has been upped to 4.4.}}
 	 */
 	if ( ( function_exists( 'wp_installing' ) && wp_installing() === false ) || ( ! function_exists( 'wp_installing' ) && ( ! defined( 'WP_INSTALLING' ) || WP_INSTALLING === false ) ) ) {
-		add_action( 'plugins_loaded', 'cmb2_conditionals_init' );
+		add_action( 'after_setup_theme', 'cmb2_conditionals_init' );
 	}
 
 	if ( ! function_exists( 'cmb2_conditionals_init' ) ) {


### PR DESCRIPTION
Change the hook for init of the plugin from plugins_loaded to after_setup_theme so those who include cmb2 in their theme can use it

Add php storm files to gitignore