### PR TITLE
Fix initialization for Gutenberg Compatibility

### DIFF
--- a/cmb2-conditionals.js
+++ b/cmb2-conditionals.js
@@ -277,5 +277,5 @@ jQuery( document ).ready( function( $ ) {
 		return result;
 	}
 
-	CMB2ConditionalsInit( '#post', '#post .cmb2-wrap' );
+	CMB2ConditionalsInit( '.cmb2-wrap' );
 });


### PR DESCRIPTION
Finally I went to simply use the .cmb2-wrap class for the initialization to keep things simple.