### PR TITLE
Composer reports an abandoned package

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     },
     "require": {
         "php": ">5.2.4",
-        "webdevstudios/cmb2": "~v2.0"
+        "cmb2/cmb2": "~v2.0"
     },
     "suggest": {
         "composer/installers": "~1.0"


### PR DESCRIPTION
"Package webdevstudios/cmb2 is abandoned, you should avoid using it. Use cmb2/cmb2 instead."