### PR TITLE
Do not try to autoload when checking if class exists.

### DIFF
--- a/cmb2-conditionals.php
+++ b/cmb2-conditionals.php
@@ -39,7 +39,7 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-if ( ! class_exists( 'CMB2_Conditionals' ) ) {
+if ( ! class_exists( 'CMB2_Conditionals', false ) ) {
 
 	/**
 	 * CMB2_Conditionals Plugin.


### PR DESCRIPTION
Avoids these PHP notices:
```
[06-Feb-2019 04:39:19 UTC] PHP Warning:  include_once(/WP-Path/wp-content/plugins/cmb2/includes/CMB2_Conditionals.php): failed to open stream: No such file or directory in /WP-Path/wp-content/plugins/cmb2/includes/helper-functions.php on line 53
[06-Feb-2019 04:39:19 UTC] PHP Warning:  include_once(): Failed opening '/WP-Path/wp-content/plugins/cmb2/includes/CMB2_Conditionals.php' for inclusion (include_path='.:') in /WP-Path/wp-content/plugins/cmb2/includes/helper-functions.php on line 53
```