### PR TITLE
Namespace custom events

### DIFF
--- a/cmb2-conditionals.js
+++ b/cmb2-conditionals.js
@@ -8,11 +8,10 @@ jQuery( document ).ready( function( $ ) {
 	$.each( ['show', 'hide'], function( i, ev ) {
 		var el = $.fn[ev];
 		$.fn[ev] = function() {
-			this.trigger( ev );
+			this.trigger( 'CMB2' + ev );
 			return el.apply( this, arguments );
 		};
 	});
-
 
 	/**
 	 * Set up the functionality for CMB2 conditionals.
@@ -143,14 +142,14 @@ jQuery( document ).ready( function( $ ) {
 		 */
 
 		// Remove the required property from form elements within rows being hidden.
-		conditionContext.on( 'hide', '.cmb-row', function() {
+		conditionContext.on( 'CMB2hide', '.cmb-row', function() {
 			$( this ).children( '[data-conditional-required="required"]' ).each( function( i, e ) {
 				$( e ).prop( 'required', false );
 			});
 		});
 
 		// Add the required property to form elements within rows being unhidden.
-		conditionContext.on( 'show', '.cmb-row', function() {
+		conditionContext.on( 'CMB2show', '.cmb-row', function() {
 			$( this ).children( '[data-conditional-required="required"]' ).each( function( i, e ) {
 				$( e ).prop( 'required', true );
 			});


### PR DESCRIPTION
The 'show' and 'hide' JQuery event detection is a neat trick, but turns out there are others doing similar things, so this can cause conflicts. By namespacing the custom event, we narrow the scope of functionality to just this plugin, and avoid conflicts w/ other scripts/plugins (namely, Visual Composer).

You can see some background here: https://wordpress.org/support/topic/wordpress-5-0-2-4/#topic-11069144-replies