### PR TITLE
Make CMB2_Conditionals object available

### DIFF
--- a/cmb2-conditionals.php
+++ b/cmb2-conditionals.php
@@ -261,7 +261,12 @@ if ( ! class_exists( 'CMB2_Conditionals' ) ) {
 		 * Initialize the class.
 		 */
 		function cmb2_conditionals_init() {
-			$cmb2_conditionals = new CMB2_Conditionals();
+			static $cmb2_conditionals = null;
+			if ( null === $cmb2_conditionals ) {
+				$cmb2_conditionals = new CMB2_Conditionals();
+			}
+
+			return $cmb2_conditionals;
 		}
 	}
 } /* End of class-exists wrapper. */


### PR DESCRIPTION
Because of #69, unhooking `CMB2_Conditionals::admin_footer` was necessary for us so we can replace w/ our own customized/fixed version, but as-is now, it will require some crazy hacks to get access to the initialized `$cmb2_conditionals` object.