### PR TITLE
fix for fieldname.replace console error in group & repeatable fields

### DIFF
--- a/cmb2-conditionals.js
+++ b/cmb2-conditionals.js
@@ -213,8 +213,10 @@ jQuery( document ).ready( function( $ ) {
 	 * Allows for within group dependencies and multi-check dependencies.
 	 */
 	function CMB2ConditionalsFindDependants( fieldName, elm, context ) {
-		var inGroup, iterator, dependants;
-
+		var inGroup, iterator;
+		var dependants = [];
+		
+		if( typeof( fieldName ) !== "undefined" ) {
 		// Remove the empty [] at the end of a multi-check field.
 		fieldName = fieldName.replace( /\[\]$/, '' );
 
@@ -232,6 +234,7 @@ jQuery( document ).ready( function( $ ) {
 		// Else within the whole form.
 		else {
 			dependants = $( '[data-conditional-id="' + fieldName + '"]', context );
+		}
 		}
 		return dependants;
 	}


### PR DESCRIPTION
Fixes issue for certain users using combination of group & repeatable fields as seen here:
https://wordpress.org/support/topic/javascript-error-in-woocommerce-admin/
http://plugin482.rssing.com/chan-13881804/all_p806.html

Not sure how to repeat this error but I had the same issue in console which was fixed by checking for the fieldname before trying the replace.

`Uncaught TypeError: Cannot read property 'replace' of undefined
    at CMB2ConditionalsFindDependants (cmb2-conditionals.js?ver=1.0.4:formatted:209)
    at HTMLSelectElement.<anonymous> (cmb2-conditionals.js?ver=1.0.4:formatted:41)`