### PR TITLE
Enable CMB2 Conditionals on front-end.

### DIFF
--- a/cmb2-conditionals.js
+++ b/cmb2-conditionals.js
@@ -19,12 +19,12 @@ jQuery( document ).ready( function( $ ) {
 	function CMB2ConditionalsInit( changeContext, conditionContext ) {
 		var loopI, requiredElms, uniqueFormElms, formElms;
 
-		if ( 'undefined' === typeof changeContext ) {
+		if ( 'undefined' === typeof changeContext || $( changeContext ).length < 1 ) {
 			changeContext = 'body';
 		}
 		changeContext = $( changeContext );
 
-		if ( 'undefined' === typeof conditionContext ) {
+		if ( 'undefined' === typeof conditionContext || $( conditionContext ).length < 1 ) {
 			conditionContext = 'body';
 		}
 		conditionContext = $( conditionContext );

--- a/cmb2-conditionals.php
+++ b/cmb2-conditionals.php
@@ -91,6 +91,9 @@ if ( ! class_exists( 'CMB2_Conditionals', false ) ) {
 			add_action( 'admin_init', array( $this, 'admin_init' ), self::PRIORITY );
 			add_action( 'admin_footer', array( $this, 'admin_footer' ), self::PRIORITY );
 
+			// Enable conditionals on front-end if using recent version of CMB2.
+			add_action( 'cmb2_footer_enqueue', array( $this, 'cmb2_footer' ), self::PRIORITY );
+
 			foreach ( $this->maybe_required_form_elms as $element ) {
 				add_filter( "cmb2_{$element}_attributes", array( $this, 'maybe_set_required_attribute' ), self::PRIORITY );
 			}
@@ -104,6 +107,21 @@ if ( ! class_exists( 'CMB2_Conditionals', false ) ) {
 		    	return;
 		    }
 
+			wp_enqueue_script(
+				'cmb2-conditionals',
+				plugins_url( '/cmb2-conditionals.js', __FILE__ ),
+				array( 'jquery', 'cmb2-scripts' ),
+				self::VERSION,
+				true
+			);
+		}
+
+		/**
+		 * Ensure the cmb2-conditionals js-script is loaded everytime the CMB2 scripts are loaded. This does
+		 * not colide with "admin_footer()" or previeous way of script enqueueing, so back compatibility
+		 * is maintained as well.
+		 */
+		public function cmb2_footer() {
 			wp_enqueue_script(
 				'cmb2-conditionals',
 				plugins_url( '/cmb2-conditionals.js', __FILE__ ),


### PR DESCRIPTION
Enable CMB2 Conditionals on front-end when using latest CMB2 version. No change for older versions.

1. The use of  "cmb2_footer_enqueue" is applied only when it is available. Meaning if user has CMB2 without this hook - nothing changes.

2. In the JS we actually check if the  "changeContext" and "conditionContext" elements exist. If not, we use the "body" selector. Again everything works as before only if the script is loaded on front-end, there is no "#post" therefore we need to use "body" instead. 