### PR TITLE
replace dot to comma for syntax error

### DIFF
--- a/example-functions.php
+++ b/example-functions.php
@@ -82,7 +82,7 @@ function yourprefix_register_conditionals_demo_metabox() {
 		'type'       => 'text',
 		'attributes' => array(
 			'data-conditional-id' => $prefix . 'checkbox',
-			// Works too: 'data-conditional-value' => 'on'.
+			'data-conditional-value' => 'on',
 		),
 	) );
 


### PR DESCRIPTION
I've on the conditional options then showing syntax error for dot, so I've changed the dot to the comma. 

Best Regards
Bashar