### PR TITLE
Allow conditionals for non-input fields

### DIFF
--- a/cmb2-conditionals.js
+++ b/cmb2-conditionals.js
@@ -62,7 +62,9 @@ jQuery( document ).ready( function( $ ) {
 				dependants.each( function( i, e ) {
 					var loopIndex        = 0,
 						current          = $( e ),
-						currentFieldName = current.attr( 'name' ),
+						// Since we may condition fields such as titles (that don't have an input with a `name` attribute), 
+					    	// fallback to their HTML `id` attribute, if they have one.
+						currentFieldName = current.attr( 'name' ) ? current.attr( 'name' ) : current.attr( 'id' ),
 						requiredValue    = current.data( 'conditional-value' ),
 						currentParent    = current.parents( '.cmb-row:first' ),
 						shouldShow       = false;


### PR DESCRIPTION
Allow for non-input fields (like titles) to be conditionally shown.

The trick involved is to use the `id` attribute as a substitute for the `name` fields of inputs to remember the seen dependents. The rest of the logic works since it relies on the parent rows.

This solves https://github.com/jcchavezs/cmb2-conditionals/issues/27